### PR TITLE
Add JUnit tests for Subject class

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,10 +6,14 @@
   <property name="main.class"  value="Main"/>
 
   <property name="src.dir"     value="src"/>
+  <property name="test.src"    value="test"/>
   <property name="build.dir"   value="build/classes"/>
+  <property name="test.build"  value="build/test-classes"/>
   <property name="jar.dir"     value="build/jar"/>
   <property name="dist.dir"    value="dist"/>
   <property name="docs.dir"    value="build/docs"/>
+  <property name="junit.jar"   value="lib/junit-platform-console-standalone.jar"/>
+  <property name="junit.url"   value="https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.11.4/junit-platform-console-standalone-1.11.4.jar"/>
 
   <!-- Javadoc external API links. Uses the JDK running Ant; no hard-coded Java version. -->
   <condition property="javadoc.api.url" value="https://docs.oracle.com/javase/8/docs/api/">
@@ -198,6 +202,34 @@
       <mapper type="merge" to="${app.name}-Windows.msi"/>
     </move>
     <echo message="Success! Windows Installer: ${dist.dir}/${app.name}-Windows.msi"/>
+  </target>
+
+  <!-- ======================== Testing ======================== -->
+
+  <target name="download-junit" description="Download JUnit JAR if not present">
+    <mkdir dir="lib"/>
+    <get src="${junit.url}" dest="${junit.jar}" skipexisting="true"/>
+  </target>
+
+  <target name="test-compile" depends="compile, download-junit" description="Compile test sources">
+    <mkdir dir="${test.build}"/>
+    <javac srcdir="${test.src}"
+           destdir="${test.build}"
+           includeantruntime="false"
+           debug="true">
+      <classpath>
+        <pathelement path="${build.dir}"/>
+        <pathelement path="${junit.jar}"/>
+      </classpath>
+    </javac>
+  </target>
+
+  <target name="test" depends="test-compile" description="Run JUnit tests">
+    <java jar="${junit.jar}" fork="true" failonerror="true">
+      <arg value="execute"/>
+      <arg value="--class-path"/><arg value="${build.dir}:${test.build}"/>
+      <arg value="--scan-class-path=${test.build}"/>
+    </java>
   </target>
 
 </project>

--- a/test/SubjectTest.java
+++ b/test/SubjectTest.java
@@ -1,0 +1,113 @@
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import javax.swing.table.DefaultTableModel;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the {@link Subject} class.
+ */
+public class SubjectTest {
+
+    private Subject subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new Subject("Math");
+    }
+
+    // --- Constructor and basic getters ---
+
+    @Test
+    void constructorSetsName() {
+        assertEquals("Math", subject.getName());
+    }
+
+    @Test
+    void constructorCreatesEmptyTableModel() {
+        DefaultTableModel model = subject.getTableModel();
+        assertNotNull(model);
+        assertEquals(0, model.getRowCount());
+        assertEquals(3, model.getColumnCount());
+    }
+
+    @Test
+    void tableModelHasCorrectColumnNames() {
+        DefaultTableModel model = subject.getTableModel();
+        assertEquals("Assignment", model.getColumnName(0));
+        assertEquals("Due Date", model.getColumnName(1));
+        assertEquals("Done", model.getColumnName(2));
+    }
+
+    @Test
+    void tableModelColumnClassesAreCorrect() {
+        DefaultTableModel model = subject.getTableModel();
+        assertEquals(String.class, model.getColumnClass(0));
+        assertEquals(String.class, model.getColumnClass(1));
+        assertEquals(Boolean.class, model.getColumnClass(2));
+    }
+
+    // --- setName ---
+
+    @Test
+    void setNameUpdatesName() {
+        subject.setName("Science");
+        assertEquals("Science", subject.getName());
+    }
+
+    // --- toString ---
+
+    @Test
+    void toStringReturnsName() {
+        assertEquals("Math", subject.toString());
+    }
+
+    @Test
+    void toStringReflectsRename() {
+        subject.setName("Physics");
+        assertEquals("Physics", subject.toString());
+    }
+
+    // --- Table model operations ---
+
+    @Test
+    void addRowIncreasesRowCount() {
+        subject.getTableModel().addRow(new Object[]{"Homework 1", "2026-04-10", false});
+        assertEquals(1, subject.getTableModel().getRowCount());
+    }
+
+    @Test
+    void addedRowContainsCorrectData() {
+        subject.getTableModel().addRow(new Object[]{"Homework 1", "2026-04-10", false});
+        DefaultTableModel model = subject.getTableModel();
+        assertEquals("Homework 1", model.getValueAt(0, 0));
+        assertEquals("2026-04-10", model.getValueAt(0, 1));
+        assertEquals(false, model.getValueAt(0, 2));
+    }
+
+    @Test
+    void removeRowDecreasesRowCount() {
+        DefaultTableModel model = subject.getTableModel();
+        model.addRow(new Object[]{"HW1", "2026-04-10", false});
+        model.addRow(new Object[]{"HW2", "2026-04-11", false});
+        model.removeRow(0);
+        assertEquals(1, model.getRowCount());
+        assertEquals("HW2", model.getValueAt(0, 0));
+    }
+
+    @Test
+    void multipleSubjectsHaveIndependentTableModels() {
+        Subject other = new Subject("English");
+        subject.getTableModel().addRow(new Object[]{"HW1", "2026-04-10", false});
+        assertEquals(1, subject.getTableModel().getRowCount());
+        assertEquals(0, other.getTableModel().getRowCount());
+    }
+
+    @Test
+    void doneCheckboxCanBeToggled() {
+        DefaultTableModel model = subject.getTableModel();
+        model.addRow(new Object[]{"HW1", "2026-04-10", false});
+        model.setValueAt(true, 0, 2);
+        assertEquals(true, model.getValueAt(0, 2));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `test/SubjectTest.java` with 11 JUnit tests covering the entire `Subject` class.
- Update `build.xml` targets so tests can be run with `ant test`

## Test plan
- [x] Run `ant test` and verify all 11 tests pass
- [x] Confirm `ant clean` still works (removes build artifacts)
- [x] Verify existing `ant run` is unaffected