### PR TITLE
Add per-assignment notes

### DIFF
--- a/src/DataStore.java
+++ b/src/DataStore.java
@@ -34,9 +34,11 @@ class DataStore {
                 String aName = (String) tm.getValueAt(r, 0);
                 String date  = (String) tm.getValueAt(r, 1);
                 Boolean done = (Boolean) tm.getValueAt(r, 2);
+                String notes = (String) tm.getValueAt(r, 3); // "" when no note
                 sb.append("      {\"name\": ").append(jsonString(aName))
                   .append(", \"date\": ").append(jsonString(date))
                   .append(", \"done\": ").append(done != null && done)
+                  .append(", \"notes\": ").append(jsonString(notes))
                   .append("}");
                 if (r < tm.getRowCount() - 1) sb.append(",");
                 sb.append("\n");
@@ -87,7 +89,9 @@ class DataStore {
                     String aName = extractStringField(row, "name");
                     String date  = extractStringField(row, "date");
                     boolean done = extractBoolField(row, "done");
-                    s.getTableModel().addRow(new Object[]{aName, date, done});
+                    // Missing "notes" field returns "" — keeps old data files compatible.
+                    String notes = extractStringField(row, "notes");
+                    s.getTableModel().addRow(new Object[]{aName, date, done, notes});
                 }
             }
             result.add(s);

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,6 +1,7 @@
 import javax.swing.*;
 import javax.swing.table.DefaultTableModel;
 import java.awt.*;
+import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.time.LocalDate;
@@ -22,6 +23,13 @@ public class Main {
      */
     public static void main(String[] args) {
         SwingUtilities.invokeLater(Main::createAndShowGUI);
+    }
+
+    /** Escapes the characters that matter for Swing's HTML tooltip renderer. */
+    private static String escapeHtml(String s) {
+        return s.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;");
     }
 
     /** Draws a small calendar icon at the given size using Java2D. */
@@ -86,8 +94,11 @@ public class Main {
                 frame.dispose();
             }
         });
+        // 4 columns to match Subject's table model (see Subject.java).
+        // The 4th column ("Notes") is hidden from the view below and edited
+        // through the Notes button.
         DefaultTableModel emptyTableModel = new DefaultTableModel(
-                new String[]{"Assignment", "Due Date", "Done"}, 0) {
+                new String[]{"Assignment", "Due Date", "Done", "Notes"}, 0) {
             @Override
             public Class<?> getColumnClass(int col) {
                 return col == 2 ? Boolean.class : String.class; // col 2 = "Done" checkbox
@@ -95,7 +106,36 @@ public class Main {
         };
 
         // --- Center: assignment table ---
-        JTable table = new JTable(emptyTableModel);
+        // Override getToolTipText so hovering a row shows its note.
+        // The Notes column is hidden from the view but still in the model at
+        // index 3, which is where we read the tooltip text from.
+        JTable table = new JTable(emptyTableModel) {
+            @Override
+            public String getToolTipText(MouseEvent e) {
+                int row = rowAtPoint(e.getPoint());
+                if (row < 0) return null;
+                Object note = getModel().getValueAt(row, 3);
+                if (note == null) return null;
+                String text = note.toString();
+                if (text.isEmpty()) return null; // no tooltip when there's no note
+                // Wrap in HTML so long notes wrap; escape user text first.
+                return "<html><p style='width:240px'>" + escapeHtml(text) + "</p></html>";
+            }
+        };
+        // JTable doesn't listen for tooltips unless a tooltip is set or the
+        // component is registered. Explicit register keeps the intent obvious.
+        ToolTipManager.sharedInstance().registerComponent(table);
+
+        // Hide the "Notes" column from the user. The data stays in the model
+        // (so saving/loading still sees it); only the view drops the column.
+        // Must be called after every setModel() because swapping the model
+        // rebuilds the JTable's column view from scratch.
+        Runnable hideNotesColumn = () -> {
+            if (table.getColumnCount() > 3) {
+                table.removeColumn(table.getColumnModel().getColumn(3));
+            }
+        };
+        hideNotesColumn.run();
         table.setRowHeight(24);
         table.setBackground(theme.contentBg());
         table.setForeground(theme.contentFg());
@@ -124,11 +164,16 @@ public class Main {
         });
         JButton addButton = new JButton("Add");
         JButton removeButton = new JButton("Remove Selected");
+        // Notes button opens a dialog to edit the selected assignment's note.
+        // Disabled until a subject AND a row are both selected.
+        JButton notesButton = new JButton("Notes…");
+        notesButton.setToolTipText("Edit notes for the selected assignment");
         nameField.setEnabled(false);
         dateField.setEnabled(false);
         datePickerButton.setEnabled(false);
         addButton.setEnabled(false);
         removeButton.setEnabled(false);
+        notesButton.setEnabled(false);
 
         JLabel darkModeLabel = new JLabel(theme.isDark() ? "Light Mode" : "Dark Mode");
         JToggleButton darkModeToggle = new JToggleButton(theme.isDark() ? "☀" : "☾");
@@ -144,6 +189,7 @@ public class Main {
         inputPanel.add(datePickerButton);
         inputPanel.add(addButton);
         inputPanel.add(removeButton);
+        inputPanel.add(notesButton);
 
         // Spacer to push toggle to the right
         inputPanel.add(Box.createHorizontalStrut(20));
@@ -210,6 +256,7 @@ public class Main {
             Subject selected = subjectList.getSelectedValue();
             boolean subjectSelected = selected != null;
             table.setModel(subjectSelected ? selected.getTableModel() : emptyTableModel);
+            hideNotesColumn.run(); // setModel rebuilds the view — re-hide Notes
             nameField.setEnabled(subjectSelected);
             dateField.setEnabled(subjectSelected);
             datePickerButton.setEnabled(subjectSelected);
@@ -217,6 +264,18 @@ public class Main {
             removeButton.setEnabled(subjectSelected);
             renameButton.setEnabled(subjectSelected);
             deleteButton.setEnabled(subjectSelected);
+            // Swapping the model clears the table selection, so the Notes
+            // button has no row to act on until the user picks one.
+            notesButton.setEnabled(false);
+        });
+
+        // Notes button needs BOTH a subject and a selected row to be enabled.
+        // The table's selection model is stable across setModel() calls, so we
+        // only need to wire this once.
+        table.getSelectionModel().addListSelectionListener(e -> {
+            if (e.getValueIsAdjusting()) return;
+            notesButton.setEnabled(subjectList.getSelectedValue() != null
+                    && table.getSelectedRow() >= 0);
         });
 
         // --- Assignment actions ---
@@ -228,7 +287,10 @@ public class Main {
             String name = nameField.getText().trim();
             String date = dateField.getText().trim(); // already MM/dd/yyyy or empty
             if (!name.isEmpty()) {
-                selected.getTableModel().addRow(new Object[]{name, date, false});
+                // New assignments start with an empty note ("" — not null,
+                // so the JSON writer and the notes dialog don't have to
+                // special-case nulls).
+                selected.getTableModel().addRow(new Object[]{name, date, false, ""});
                 nameField.setText("");
                 dateField.setText("");
                 pickedDate[0] = null;
@@ -245,6 +307,34 @@ public class Main {
             if (row >= 0) {
                 selected.getTableModel().removeRow(row);
                 calendarPanel.refresh(); // keep due-date markers in sync
+            }
+        });
+
+        // --- Edit notes for the selected row ---
+        // Opens a small dialog with a multi-line text area pre-filled with
+        // the current note. On OK, writes the text back into the hidden
+        // Notes column (index 3) of the subject's table model.
+        notesButton.addActionListener(e -> {
+            Subject selected = subjectList.getSelectedValue();
+            if (selected == null) return;
+            int row = table.getSelectedRow();
+            if (row < 0) return;
+
+            DefaultTableModel tm = selected.getTableModel();
+            String assignmentName = (String) tm.getValueAt(row, 0);
+            String currentNote = (String) tm.getValueAt(row, 3);
+            if (currentNote == null) currentNote = ""; // defensive for older data
+
+            JTextArea area = new JTextArea(currentNote, 4, 32);
+            area.setLineWrap(true);
+            area.setWrapStyleWord(true);
+            JScrollPane sp = new JScrollPane(area);
+
+            int result = JOptionPane.showConfirmDialog(frame, sp,
+                    "Notes — " + assignmentName,
+                    JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+            if (result == JOptionPane.OK_OPTION) {
+                tm.setValueAt(area.getText(), row, 3);
             }
         });
 

--- a/src/Subject.java
+++ b/src/Subject.java
@@ -14,8 +14,12 @@ public class Subject {
      */
     public Subject(String name) {
         this.name = name;
+        // Columns: Assignment, Due Date, Done, Notes.
+        // The Notes column is hidden from the user-facing JTable (see Main)
+        // and edited through a separate dialog. It is kept in the table model
+        // so each row carries its own note without a parallel data structure.
         this.tableModel = new DefaultTableModel(
-                new String[]{"Assignment", "Due Date", "Done"}, 0) {
+                new String[]{"Assignment", "Due Date", "Done", "Notes"}, 0) {
             @Override
             public Class<?> getColumnClass(int col) {
                 return col == 2 ? Boolean.class : String.class; // col 2 = "Done" checkbox

--- a/test/DataStoreTest.java
+++ b/test/DataStoreTest.java
@@ -255,6 +255,79 @@ public class DataStoreTest {
     }
 
     // -----------------------------------------------------------------------
+    // Notes field (added in a later version)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void saveAndLoad_noteRoundTrip() {
+        Subject s = subjectWithAssignments("Math",
+                new Object[]{"HW1", "04/20/2026", false, "Review chapters 3-5"}
+        );
+        DataStore.save(modelWith(s));
+
+        DefaultListModel<Subject> loaded = new DefaultListModel<>();
+        DataStore.load(loaded);
+
+        assertEquals("Review chapters 3-5",
+                loaded.get(0).getTableModel().getValueAt(0, 3));
+    }
+
+    @Test
+    void saveAndLoad_emptyNotePreserved() {
+        Subject s = subjectWithAssignments("Math",
+                new Object[]{"HW1", "04/20/2026", false, ""}
+        );
+        DataStore.save(modelWith(s));
+
+        DefaultListModel<Subject> loaded = new DefaultListModel<>();
+        DataStore.load(loaded);
+
+        assertEquals("", loaded.get(0).getTableModel().getValueAt(0, 3));
+    }
+
+    @Test
+    void saveAndLoad_noteWithSpecialChars() {
+        // Quotes, backslash, and newline all need JSON escaping.
+        String original = "Said \"check page 5\".\nAlso C:\\path.";
+        Subject s = subjectWithAssignments("Math",
+                new Object[]{"HW1", "04/20/2026", false, original}
+        );
+        DataStore.save(modelWith(s));
+
+        DefaultListModel<Subject> loaded = new DefaultListModel<>();
+        DataStore.load(loaded);
+
+        assertEquals(original, loaded.get(0).getTableModel().getValueAt(0, 3));
+    }
+
+    /**
+     * Backward compatibility: a JSON file written by an older version of the
+     * app has no "notes" field on each assignment. Loading must still succeed
+     * and set each row's note to the empty string.
+     */
+    @Test
+    void load_legacyJsonWithoutNotesField_setsEmptyNote() throws Exception {
+        String legacy = "[\n" +
+                "  {\n" +
+                "    \"name\": \"Math\",\n" +
+                "    \"assignments\": [\n" +
+                "      {\"name\": \"HW1\", \"date\": \"04/20/2026\", \"done\": false}\n" +
+                "    ]\n" +
+                "  }\n" +
+                "]\n";
+        Files.write(tempFile, legacy.getBytes(StandardCharsets.UTF_8));
+
+        DefaultListModel<Subject> loaded = new DefaultListModel<>();
+        DataStore.load(loaded);
+
+        assertEquals(1, loaded.size());
+        DefaultTableModel tm = loaded.get(0).getTableModel();
+        assertEquals(1, tm.getRowCount());
+        assertEquals("HW1", tm.getValueAt(0, 0));
+        assertEquals("",    tm.getValueAt(0, 3)); // missing field → ""
+    }
+
+    // -----------------------------------------------------------------------
     // Idempotency: save → load → save → load produces the same result
     // -----------------------------------------------------------------------
 

--- a/test/SubjectTest.java
+++ b/test/SubjectTest.java
@@ -28,7 +28,8 @@ public class SubjectTest {
         DefaultTableModel model = subject.getTableModel();
         assertNotNull(model);
         assertEquals(0, model.getRowCount());
-        assertEquals(3, model.getColumnCount());
+        // 4 columns: Assignment, Due Date, Done, Notes
+        assertEquals(4, model.getColumnCount());
     }
 
     @Test
@@ -37,6 +38,7 @@ public class SubjectTest {
         assertEquals("Assignment", model.getColumnName(0));
         assertEquals("Due Date", model.getColumnName(1));
         assertEquals("Done", model.getColumnName(2));
+        assertEquals("Notes", model.getColumnName(3));
     }
 
     @Test
@@ -45,6 +47,7 @@ public class SubjectTest {
         assertEquals(String.class, model.getColumnClass(0));
         assertEquals(String.class, model.getColumnClass(1));
         assertEquals(Boolean.class, model.getColumnClass(2));
+        assertEquals(String.class, model.getColumnClass(3));
     }
 
     // --- setName ---
@@ -109,5 +112,22 @@ public class SubjectTest {
         model.addRow(new Object[]{"HW1", "2026-04-10", false});
         model.setValueAt(true, 0, 2);
         assertEquals(true, model.getValueAt(0, 2));
+    }
+
+    // --- Notes column ---
+
+    @Test
+    void addRowStoresNoteInColumn3() {
+        DefaultTableModel model = subject.getTableModel();
+        model.addRow(new Object[]{"HW1", "2026-04-10", false, "Cite sources"});
+        assertEquals("Cite sources", model.getValueAt(0, 3));
+    }
+
+    @Test
+    void noteCanBeUpdatedAfterAdd() {
+        DefaultTableModel model = subject.getTableModel();
+        model.addRow(new Object[]{"HW1", "2026-04-10", false, ""});
+        model.setValueAt("Updated", 0, 3);
+        assertEquals("Updated", model.getValueAt(0, 3));
     }
 }


### PR DESCRIPTION
Closes #18

## Summary
- Assignments now carry a user-editable note, persisted alongside name/date/done.
- New "Notes…" button opens a multi-line editor for the selected row; hovering a row shows its note as a wrapped tooltip.
- Existing data files without a `"notes"` field load cleanly with empty notes (backward compatible).

## Changes
- `Subject`: table model gains a 4th `Notes` column (hidden from the JTable view, kept in the model so each row owns its note).
- `DataStore`: writes/reads a `"notes"` JSON field. Missing field on load resolves to `""` via the existing parser behavior.
- `Main`: `getToolTipText(MouseEvent)` override on the `JTable` renders the note on hover (HTML-wrapped, user text escaped). `Notes…` button is enabled only when a subject AND a row are both selected.
- Tests: extended `SubjectTest` for the new column, added notes round-trip and special-char tests to `DataStoreTest`, and added a legacy-JSON load test that asserts old files without `"notes"` load as `""`.

## Test plan
- [x] `ant test` — all 34 tests pass (was 28; 6 added)
- [x] `ant compile` / `ant jar` build clean
- [x] Manual UI check: add an assignment, click "Notes…", save a 1-2 sentence note, close and reopen the app — note persists
- [x] Manual UI check: hover the row, tooltip shows the note; rows with no note show no tooltip
- [x] Manual UI check: load an existing `~/.assignmenttracker_data.json` from before this change — all rows load with empty notes, no errors