### PR TITLE
Modernize UI with FlatLaf (dark-mode-first)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -14,6 +14,9 @@
   <property name="docs.dir"    value="build/docs"/>
   <property name="junit.jar"   value="lib/junit-platform-console-standalone.jar"/>
   <property name="junit.url"   value="https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.11.4/junit-platform-console-standalone-1.11.4.jar"/>
+  <!-- FlatLaf: modern Look & Feel for Swing. Auto-downloaded like junit.jar. -->
+  <property name="flatlaf.jar" value="lib/flatlaf-3.5.4.jar"/>
+  <property name="flatlaf.url" value="https://repo1.maven.org/maven2/com/formdev/flatlaf/3.5.4/flatlaf-3.5.4.jar"/>
 
   <!-- Javadoc external API links. Uses the JDK running Ant; no hard-coded Java version. -->
   <condition property="javadoc.api.url" value="https://docs.oracle.com/javase/8/docs/api/">
@@ -92,14 +95,25 @@
     <delete dir="${dist.dir}"/>
   </target>
 
-  <target name="compile" depends="preflight" description="Compile Java source code">
+  <target name="download-flatlaf" description="Download FlatLaf JAR if not present">
+    <mkdir dir="lib"/>
+    <get src="${flatlaf.url}" dest="${flatlaf.jar}" skipexisting="true"/>
+  </target>
+
+  <target name="compile" depends="preflight, download-flatlaf" description="Compile Java source code">
     <mkdir dir="${build.dir}"/>
     <javac srcdir="${src.dir}"
            destdir="${build.dir}"
            includeantruntime="false"
-           debug="true"/>
+           debug="true">
+      <classpath>
+        <pathelement path="${flatlaf.jar}"/>
+      </classpath>
+    </javac>
   </target>
 
+  <!-- Bundle FlatLaf classes into the app JAR so `ant run` and jpackage both
+       work without needing a separate classpath entry. -->
   <target name="jar" depends="compile" description="Package classes into an executable JAR">
     <mkdir dir="${jar.dir}"/>
     <jar destfile="${jar.dir}/${app.name}.jar" basedir="${build.dir}">
@@ -107,6 +121,7 @@
         <attribute name="Main-Class" value="${main.class}"/>
         <attribute name="Implementation-Version" value="${app.version}"/>
       </manifest>
+      <zipgroupfileset file="${flatlaf.jar}"/>
     </jar>
   </target>
 

--- a/src/CalendarPanel.java
+++ b/src/CalendarPanel.java
@@ -15,7 +15,9 @@ import javax.swing.table.DefaultTableModel;
 
 /**
  * Month-view calendar. Reads assignments from the subject list model and
- * highlights any date that has something due.
+ * highlights any date that has something due. All colors come from the
+ * current Look & Feel via UIManager so the panel stays in sync with FlatLaf's
+ * light/dark themes.
  */
 public class CalendarPanel extends JPanel {
 
@@ -25,7 +27,6 @@ public class CalendarPanel extends JPanel {
 
     private JLabel monthYearLabel;
     private JPanel gridPanel;
-    private JPanel header;
 
     /** Source of assignments; may be null for a standalone calendar. */
     private final DefaultListModel<Subject> subjectModel;
@@ -42,17 +43,13 @@ public class CalendarPanel extends JPanel {
         this.subjectModel = subjectModel;
         this.displayedMonth = YearMonth.now();
         setLayout(new BorderLayout());
-        header = buildHeader();
-        add(header, BorderLayout.NORTH);
+        add(buildHeader(), BorderLayout.NORTH);
         gridPanel = new JPanel();
         add(gridPanel, BorderLayout.CENTER);
         rebuildGrid();
 
-        // Repaint when theme changes
-        ThemeManager.get().addListener(() -> {
-            applyHeaderTheme();
-            rebuildGrid();
-        });
+        // Rebuild so UIManager colors are re-queried after a theme switch.
+        ThemeManager.get().addListener(this::rebuildGrid);
     }
 
     /** Rebuilds the grid so newly added/removed assignments show up. */
@@ -60,28 +57,13 @@ public class CalendarPanel extends JPanel {
         rebuildGrid();
     }
 
-    private void applyHeaderTheme() {
-        ThemeManager tm = ThemeManager.get();
-        header.setBackground(tm.calHeaderBg());
-        monthYearLabel.setForeground(tm.calHeaderFg());
-        // Update nav buttons (first and last components)
-        for (Component c : header.getComponents()) {
-            if (c instanceof JButton) {
-                JButton btn = (JButton) c;
-                btn.setForeground(tm.calHeaderFg());
-                btn.setBackground(tm.calHeaderBg());
-            }
-        }
-    }
-
     private JPanel buildHeader() {
-        ThemeManager tm = ThemeManager.get();
         JPanel h = new JPanel(new BorderLayout());
-        h.setBackground(tm.calHeaderBg());
+        h.setOpaque(false);
         h.setBorder(BorderFactory.createEmptyBorder(8, 12, 8, 12));
 
-        JButton prevButton = makeNavButton("\u25C0"); // left triangle
-        JButton nextButton = makeNavButton("\u25B6"); // right triangle
+        JButton prevButton = makeNavButton("\u25C0");
+        JButton nextButton = makeNavButton("\u25B6");
 
         prevButton.addActionListener(e -> {
             displayedMonth = displayedMonth.minusMonths(1);
@@ -93,8 +75,7 @@ public class CalendarPanel extends JPanel {
         });
 
         monthYearLabel = new JLabel("", SwingConstants.CENTER);
-        monthYearLabel.setForeground(tm.calHeaderFg());
-        monthYearLabel.setFont(new Font("SansSerif", Font.BOLD, 16));
+        monthYearLabel.setFont(monthYearLabel.getFont().deriveFont(Font.BOLD, 16f));
 
         h.add(prevButton,     BorderLayout.WEST);
         h.add(monthYearLabel, BorderLayout.CENTER);
@@ -103,26 +84,24 @@ public class CalendarPanel extends JPanel {
     }
 
     private JButton makeNavButton(String symbol) {
-        ThemeManager tm = ThemeManager.get();
         JButton btn = new JButton(symbol);
-        btn.setForeground(tm.calHeaderFg());
-        btn.setBackground(tm.calHeaderBg());
-        btn.setBorderPainted(false);
-        btn.setFocusPainted(false);
-        btn.setFont(new Font("SansSerif", Font.BOLD, 14));
+        // FlatLaf styles this as a borderless toolbar-style button.
+        btn.putClientProperty("JButton.buttonType", "toolBarButton");
+        btn.setFont(btn.getFont().deriveFont(Font.BOLD, 14f));
         return btn;
     }
 
     private void rebuildGrid() {
-        ThemeManager tm = ThemeManager.get();
         String monthName = displayedMonth.getMonth()
                 .getDisplayName(TextStyle.FULL, Locale.getDefault());
         monthYearLabel.setText(monthName + " " + displayedMonth.getYear());
 
+        Color gridLine = UIManager.getColor("Component.borderColor");
+
         remove(gridPanel);
         gridPanel = new JPanel(new GridLayout(0, 7, 1, 1));
-        gridPanel.setBackground(tm.calGridLine());
-        gridPanel.setBorder(BorderFactory.createLineBorder(tm.calGridLine()));
+        gridPanel.setBackground(gridLine);
+        gridPanel.setBorder(BorderFactory.createLineBorder(gridLine));
 
         addDayNameRow();
         addDateCells(collectDueDates());
@@ -133,14 +112,15 @@ public class CalendarPanel extends JPanel {
     }
 
     private void addDayNameRow() {
-        ThemeManager tm = ThemeManager.get();
+        Color bg = UIManager.getColor("TableHeader.background");
+        Color fg = UIManager.getColor("TableHeader.foreground");
         String[] dayNames = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
         for (String name : dayNames) {
             JLabel label = new JLabel(name, SwingConstants.CENTER);
             label.setOpaque(true);
-            label.setBackground(tm.calDayNameBg());
-            label.setForeground(tm.calDayNameFg());
-            label.setFont(new Font("SansSerif", Font.BOLD, 12));
+            label.setBackground(bg);
+            label.setForeground(fg);
+            label.setFont(label.getFont().deriveFont(Font.BOLD, 12f));
             label.setBorder(BorderFactory.createEmptyBorder(6, 0, 6, 0));
             gridPanel.add(label);
         }
@@ -212,29 +192,36 @@ public class CalendarPanel extends JPanel {
 
     private JPanel buildDateCell(LocalDate date, boolean isThisMonth,
                                  boolean isToday, List<String> due) {
-        ThemeManager tm = ThemeManager.get();
+        Color thisMonthBg  = UIManager.getColor("Table.background");
+        Color otherMonthBg = UIManager.getColor("Panel.background");
+        Color todayBg      = UIManager.getColor("Table.selectionBackground");
+        Color todayFg      = UIManager.getColor("Table.selectionForeground");
+        Color normalFg     = UIManager.getColor("Label.foreground");
+        Color mutedFg      = UIManager.getColor("Label.disabledForeground");
+        Color hoverBorder  = UIManager.getColor("Component.focusColor");
+
         JPanel cell = new JPanel(new BorderLayout());
         cell.setBorder(BorderFactory.createEmptyBorder(4, 6, 4, 6));
         cell.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 
         if (isToday) {
-            cell.setBackground(tm.calTodayBg());
+            cell.setBackground(todayBg);
         } else if (isThisMonth) {
-            cell.setBackground(tm.calThisMonthBg());
+            cell.setBackground(thisMonthBg);
         } else {
-            cell.setBackground(tm.calOtherMonthBg());
+            cell.setBackground(otherMonthBg);
         }
 
         JLabel dateLabel = new JLabel(String.valueOf(date.getDayOfMonth()));
-        dateLabel.setFont(new Font("SansSerif", isToday ? Font.BOLD : Font.PLAIN, 13));
-        dateLabel.setForeground(isThisMonth ? tm.calDateFg() : tm.calOtherMonthFg());
+        dateLabel.setFont(dateLabel.getFont().deriveFont(isToday ? Font.BOLD : Font.PLAIN, 13f));
+        dateLabel.setForeground(isToday ? todayFg : (isThisMonth ? normalFg : mutedFg));
         cell.add(dateLabel, BorderLayout.NORTH);
 
         // Show a small dot and a count when this date has assignments due.
         if (due != null && !due.isEmpty()) {
             JLabel marker = new JLabel("\u25CF " + due.size(), SwingConstants.CENTER);
             marker.setForeground(DUE_DOT);
-            marker.setFont(new Font("SansSerif", Font.BOLD, 11));
+            marker.setFont(marker.getFont().deriveFont(Font.BOLD, 11f));
             cell.add(marker, BorderLayout.CENTER);
             cell.setToolTipText(tooltipFor(due));
         }
@@ -242,7 +229,7 @@ public class CalendarPanel extends JPanel {
         cell.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseEntered(MouseEvent e) {
-                cell.setBorder(BorderFactory.createLineBorder(tm.calHoverBorder(), 2));
+                cell.setBorder(BorderFactory.createLineBorder(hoverBorder, 2));
             }
             @Override
             public void mouseExited(MouseEvent e) {

--- a/src/CalendarPanel.java
+++ b/src/CalendarPanel.java
@@ -49,7 +49,12 @@ public class CalendarPanel extends JPanel {
         rebuildGrid();
 
         // Rebuild so UIManager colors are re-queried after a theme switch.
-        ThemeManager.get().addListener(this::rebuildGrid);
+        // Deferred via invokeLater so the rebuild runs AFTER the LAF-swap
+        // listener (and FlatLaf.updateUI) finishes — otherwise cells get
+        // built with the old theme's UIResource colors, which Swing then
+        // overwrites with the new LAF's Panel.background defaults during
+        // updateUI, wiping the today highlight.
+        ThemeManager.get().addListener(() -> SwingUtilities.invokeLater(this::rebuildGrid));
     }
 
     /** Rebuilds the grid so newly added/removed assignments show up. */

--- a/src/DatePickerDialog.java
+++ b/src/DatePickerDialog.java
@@ -9,6 +9,9 @@ import java.util.Locale;
 /**
  * A small modal calendar popup that lets the user click a date to select it.
  * Returns the chosen date as a LocalDate, or null if the dialog was cancelled.
+ *
+ * Colors come from the current Look & Feel via UIManager so the popup matches
+ * FlatLaf's theme.
  */
 public class DatePickerDialog extends JDialog {
 
@@ -64,17 +67,15 @@ public class DatePickerDialog extends JDialog {
     // -----------------------------------------------------------------------
 
     private JPanel buildHeader() {
-        ThemeManager tm = ThemeManager.get();
         JPanel header = new JPanel(new BorderLayout());
-        header.setBackground(tm.calHeaderBg());
+        header.setOpaque(false);
         header.setBorder(BorderFactory.createEmptyBorder(6, 10, 6, 10));
 
         JButton prev = makeNavBtn("\u25C0");
         JButton next = makeNavBtn("\u25B6");
 
         monthYearLabel = new JLabel("", SwingConstants.CENTER);
-        monthYearLabel.setForeground(tm.calHeaderFg());
-        monthYearLabel.setFont(new Font("SansSerif", Font.BOLD, 14));
+        monthYearLabel.setFont(monthYearLabel.getFont().deriveFont(Font.BOLD, 14f));
 
         prev.addActionListener(e -> {
             displayedMonth = displayedMonth.minusMonths(1);
@@ -92,13 +93,9 @@ public class DatePickerDialog extends JDialog {
     }
 
     private JButton makeNavBtn(String symbol) {
-        ThemeManager tm = ThemeManager.get();
         JButton btn = new JButton(symbol);
-        btn.setForeground(tm.calHeaderFg());
-        btn.setBackground(tm.calHeaderBg());
-        btn.setBorderPainted(false);
-        btn.setFocusPainted(false);
-        btn.setFont(new Font("SansSerif", Font.BOLD, 13));
+        btn.putClientProperty("JButton.buttonType", "toolBarButton");
+        btn.setFont(btn.getFont().deriveFont(Font.BOLD, 13f));
         return btn;
     }
 
@@ -107,24 +104,27 @@ public class DatePickerDialog extends JDialog {
     // -----------------------------------------------------------------------
 
     private void rebuildGrid(LocalDate highlighted) {
-        ThemeManager tm = ThemeManager.get();
         String monthName = displayedMonth.getMonth()
                 .getDisplayName(TextStyle.FULL, Locale.getDefault());
         monthYearLabel.setText(monthName + " " + displayedMonth.getYear());
 
+        Color gridLine   = UIManager.getColor("Component.borderColor");
+        Color dayNameBg  = UIManager.getColor("TableHeader.background");
+        Color dayNameFg  = UIManager.getColor("TableHeader.foreground");
+
         remove(gridPanel);
         gridPanel = new JPanel(new GridLayout(0, 7, 1, 1));
-        gridPanel.setBackground(tm.calGridLine());
-        gridPanel.setBorder(new LineBorder(tm.calGridLine()));
+        gridPanel.setBackground(gridLine);
+        gridPanel.setBorder(new LineBorder(gridLine));
 
         // Day-name row
         String[] dayNames = {"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"};
         for (String n : dayNames) {
             JLabel lbl = new JLabel(n, SwingConstants.CENTER);
             lbl.setOpaque(true);
-            lbl.setBackground(tm.calDayNameBg());
-            lbl.setForeground(tm.calDayNameFg());
-            lbl.setFont(new Font("SansSerif", Font.BOLD, 11));
+            lbl.setBackground(dayNameBg);
+            lbl.setForeground(dayNameFg);
+            lbl.setFont(lbl.getFont().deriveFont(Font.BOLD, 11f));
             lbl.setBorder(BorderFactory.createEmptyBorder(4, 0, 4, 0));
             gridPanel.add(lbl);
         }
@@ -145,9 +145,16 @@ public class DatePickerDialog extends JDialog {
     }
 
     private JPanel buildCell(LocalDate date, LocalDate today, LocalDate highlighted) {
-        ThemeManager tm = ThemeManager.get();
-        boolean isThisMonth  = YearMonth.from(date).equals(displayedMonth);
-        boolean isToday      = date.equals(today);
+        Color thisMonthBg  = UIManager.getColor("Table.background");
+        Color otherMonthBg = UIManager.getColor("Panel.background");
+        Color todayBg      = UIManager.getColor("Table.selectionBackground");
+        Color todayFg      = UIManager.getColor("Table.selectionForeground");
+        Color normalFg     = UIManager.getColor("Label.foreground");
+        Color mutedFg      = UIManager.getColor("Label.disabledForeground");
+        Color hoverBorder  = UIManager.getColor("Component.focusColor");
+
+        boolean isThisMonth   = YearMonth.from(date).equals(displayedMonth);
+        boolean isToday       = date.equals(today);
         boolean isHighlighted = date.equals(highlighted);
 
         JPanel cell = new JPanel(new BorderLayout());
@@ -155,23 +162,21 @@ public class DatePickerDialog extends JDialog {
         cell.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 
         Color bg;
-        if (isHighlighted) {
-            bg = tm.calHoverBorder();
-        } else if (isToday) {
-            bg = tm.calTodayBg();
+        if (isHighlighted || isToday) {
+            bg = todayBg;
         } else if (isThisMonth) {
-            bg = tm.calThisMonthBg();
+            bg = thisMonthBg;
         } else {
-            bg = tm.calOtherMonthBg();
+            bg = otherMonthBg;
         }
         cell.setBackground(bg);
         cell.setBorder(BorderFactory.createEmptyBorder(3, 4, 3, 4));
 
         JLabel lbl = new JLabel(String.valueOf(date.getDayOfMonth()), SwingConstants.CENTER);
-        lbl.setFont(new Font("SansSerif", isToday ? Font.BOLD : Font.PLAIN, 12));
-        Color fg = isHighlighted ? Color.WHITE
-                 : isThisMonth   ? tm.calDateFg()
-                 :                 tm.calOtherMonthFg();
+        lbl.setFont(lbl.getFont().deriveFont(isToday ? Font.BOLD : Font.PLAIN, 12f));
+        Color fg = (isHighlighted || isToday) ? todayFg
+                 : isThisMonth                ? normalFg
+                 :                              mutedFg;
         lbl.setForeground(fg);
         cell.add(lbl, BorderLayout.CENTER);
 
@@ -184,7 +189,7 @@ public class DatePickerDialog extends JDialog {
             }
             @Override
             public void mouseEntered(MouseEvent e) {
-                cell.setBorder(new LineBorder(tm.calHoverBorder(), 2));
+                cell.setBorder(new LineBorder(hoverBorder, 2));
             }
             @Override
             public void mouseExited(MouseEvent e) {

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,3 +1,7 @@
+import com.formdev.flatlaf.FlatDarkLaf;
+import com.formdev.flatlaf.FlatLaf;
+import com.formdev.flatlaf.FlatLightLaf;
+
 import javax.swing.*;
 import javax.swing.table.DefaultTableModel;
 import java.awt.*;
@@ -21,6 +25,14 @@ public class Main {
      * @param args ignored
      */
     public static void main(String[] args) {
+        // Install FlatLaf before any Swing component is created so it picks up
+        // the modern Look & Feel defaults (fonts, borders, scrollbars, etc.).
+        // Choice of dark vs. light follows the saved ThemeManager preference.
+        if (ThemeManager.get().isDark()) {
+            FlatDarkLaf.setup();
+        } else {
+            FlatLightLaf.setup();
+        }
         SwingUtilities.invokeLater(Main::createAndShowGUI);
     }
 
@@ -72,7 +84,9 @@ public class Main {
 
         JFrame frame = new JFrame("Assignment Tracker");
         frame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
-        frame.setSize(750, 550);
+        // Default size sized so the full input row (assignment, due date,
+        // buttons, and dark-mode toggle) fits without wrapping.
+        frame.setSize(1100, 650);
         frame.setLocationRelativeTo(null);
 
         // --- Data models ---
@@ -95,12 +109,10 @@ public class Main {
         };
 
         // --- Center: assignment table ---
+        // Colors come from the active FlatLaf theme via UIManager; only
+        // layout/size tweaks are set here.
         JTable table = new JTable(emptyTableModel);
         table.setRowHeight(24);
-        table.setBackground(theme.contentBg());
-        table.setForeground(theme.contentFg());
-        table.getTableHeader().setBackground(theme.contentBg());
-        table.getTableHeader().setForeground(theme.contentFg());
 
         // --- South: input panel (disabled until a class is selected) ---
         DateTimeFormatter displayFmt = DateTimeFormatter.ofPattern("MM/dd/yyyy");
@@ -153,30 +165,35 @@ public class Main {
         // --- West: sidebar ---
         JList<Subject> subjectList = new JList<>(subjectListModel);
         subjectList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        subjectList.setBackground(theme.sidebarBg());
-        subjectList.setForeground(theme.sidebarFg());
-        subjectList.setSelectionBackground(theme.sidebarSelBg());
-        subjectList.setSelectionForeground(theme.sidebarSelFg());
         subjectList.setFont(subjectList.getFont().deriveFont(13f));
 
-        JButton newClassButton = new JButton("New Class");
-        JButton renameButton = new JButton("Rename");
-        JButton deleteButton = new JButton("Delete");
+        // Sidebar action buttons are icon-only (monochrome Unicode glyphs so
+        // FlatLaf handles the color automatically). Tooltips carry the
+        // full label for accessibility.
+        JButton newClassButton = new JButton("+");
+        newClassButton.setToolTipText("New class");
+        JButton renameButton = new JButton("\u270E"); // pencil
+        renameButton.setToolTipText("Rename class");
+        JButton deleteButton = new JButton("\u2715"); // heavy X
+        deleteButton.setToolTipText("Delete class");
+        // Bump the glyph size so the icons read clearly on smaller buttons.
+        Font iconFont = newClassButton.getFont().deriveFont(18f);
+        newClassButton.setFont(iconFont);
+        renameButton.setFont(iconFont);
+        deleteButton.setFont(iconFont);
         renameButton.setEnabled(false);
         deleteButton.setEnabled(false);
 
-        JPanel sidebarButtonPanel = new JPanel(new GridLayout(3, 1, 0, 2));
+        // Horizontal row of equally-sized icon buttons.
+        JPanel sidebarButtonPanel = new JPanel(new GridLayout(1, 3, 4, 0));
         sidebarButtonPanel.add(newClassButton);
         sidebarButtonPanel.add(renameButton);
         sidebarButtonPanel.add(deleteButton);
-        sidebarButtonPanel.setBackground(theme.sidebarBg());
 
         JScrollPane sidebarScroll = new JScrollPane(subjectList);
-        sidebarScroll.getViewport().setBackground(theme.sidebarBg());
 
-        JPanel sidebarPanel = new JPanel(new BorderLayout(0, 4));
-        sidebarPanel.setPreferredSize(new Dimension(150, 0));
-        sidebarPanel.setBackground(theme.sidebarBg());
+        JPanel sidebarPanel = new JPanel(new BorderLayout(0, 6));
+        sidebarPanel.setPreferredSize(new Dimension(210, 0));
         sidebarPanel.setBorder(BorderFactory.createEmptyBorder(4, 4, 4, 4));
         sidebarPanel.add(sidebarScroll, BorderLayout.CENTER);
         sidebarPanel.add(sidebarButtonPanel, BorderLayout.SOUTH);
@@ -186,20 +203,18 @@ public class Main {
         // can capture it and call refresh() when assignments change.
         CalendarPanel calendarPanel = new CalendarPanel(subjectListModel);
 
-        // Theme listener registered later (after tableScroll/tabs are in scope)
-
-        // Apply initial theme to input panel and frame background
-        inputPanel.setBackground(theme.contentBg());
-        nameField.setBackground(theme.inputBg());
-        nameField.setForeground(theme.inputFg());
-        dateField.setBackground(theme.inputBg());
-        dateField.setForeground(theme.inputFg());
-        frame.getContentPane().setBackground(theme.contentBg());
-        for (Component c : inputPanel.getComponents()) {
-            if (c instanceof JLabel) {
-                ((JLabel) c).setForeground(theme.contentFg());
+        // Swap the FlatLaf Look & Feel when the user toggles dark/light mode.
+        // Registered FIRST so it runs before the color-override listener below
+        // (which sets specific component colors on top of the LAF defaults).
+        theme.addListener(() -> {
+            try {
+                UIManager.setLookAndFeel(theme.isDark()
+                        ? new FlatDarkLaf() : new FlatLightLaf());
+                FlatLaf.updateUI(); // repaint every open window with the new LAF
+            } catch (UnsupportedLookAndFeelException ex) {
+                System.err.println("Could not switch LAF: " + ex.getMessage());
             }
-        }
+        });
 
         // --- Dark mode toggle action ---
         darkModeToggle.addActionListener(e -> theme.toggle());
@@ -319,58 +334,17 @@ public class Main {
 
         // --- Assemble frame ---
         JScrollPane tableScroll = new JScrollPane(table);
-        tableScroll.getViewport().setBackground(theme.contentBg());
-        tableScroll.setBackground(theme.contentBg());
 
         JTabbedPane tabs = new JTabbedPane();
-        tabs.setBackground(theme.contentBg());
-        tabs.setForeground(theme.contentFg());
         tabs.addTab("Assignments", tableScroll);
         tabs.addTab("Calendar", calendarPanel);
 
-        // --- Theme change listener: recolor all non-calendar components ---
+        // Component colors are handled by the FlatLaf LAF swap registered
+        // above. This listener only updates text that reflects the current
+        // mode (the sun/moon icon and the label next to it).
         theme.addListener(() -> {
-            // Table
-            table.setBackground(theme.contentBg());
-            table.setForeground(theme.contentFg());
-            table.getTableHeader().setBackground(theme.contentBg());
-            table.getTableHeader().setForeground(theme.contentFg());
-            tableScroll.getViewport().setBackground(theme.contentBg());
-            tableScroll.setBackground(theme.contentBg());
-
-            // Tabs
-            tabs.setBackground(theme.contentBg());
-            tabs.setForeground(theme.contentFg());
-
-            // Sidebar
-            subjectList.setBackground(theme.sidebarBg());
-            subjectList.setForeground(theme.sidebarFg());
-            subjectList.setSelectionBackground(theme.sidebarSelBg());
-            subjectList.setSelectionForeground(theme.sidebarSelFg());
-            sidebarButtonPanel.setBackground(theme.sidebarBg());
-            sidebarScroll.getViewport().setBackground(theme.sidebarBg());
-            sidebarPanel.setBackground(theme.sidebarBg());
-
-            // Input panel
-            inputPanel.setBackground(theme.contentBg());
-            nameField.setBackground(theme.inputBg());
-            nameField.setForeground(theme.inputFg());
-            dateField.setBackground(theme.inputBg());
-            dateField.setForeground(theme.inputFg());
-
-            // Toggle button label
             darkModeToggle.setText(theme.isDark() ? "☀" : "☾");
             darkModeLabel.setText(theme.isDark() ? "Light Mode" : "Dark Mode");
-
-            // Labels in input panel
-            for (Component c : inputPanel.getComponents()) {
-                if (c instanceof JLabel) {
-                    ((JLabel) c).setForeground(theme.contentFg());
-                }
-            }
-
-            frame.getContentPane().setBackground(theme.contentBg());
-            frame.repaint();
         });
 
         // Redraw the calendar whenever the user switches to its tab so any

--- a/src/ThemeManager.java
+++ b/src/ThemeManager.java
@@ -1,69 +1,16 @@
-import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.prefs.Preferences;
 
 /**
- * Manages light/dark theme colors for the application.
- * Listeners are notified whenever the theme changes so components can repaint.
+ * Tracks the current light/dark theme preference and notifies listeners when
+ * it changes. Actual component colors come from FlatLaf via UIManager — this
+ * class only owns the on/off switch and the persistence of that choice.
  */
 public class ThemeManager {
 
     public enum Theme { LIGHT, DARK }
 
-    // -----------------------------------------------------------------------
-    // Light theme colors
-    // -----------------------------------------------------------------------
-    public static final Color LIGHT_CAL_HEADER_BG      = new Color(45, 45, 48);
-    public static final Color LIGHT_CAL_HEADER_FG      = Color.WHITE;
-    public static final Color LIGHT_CAL_DAY_NAME_BG    = new Color(60, 60, 65);
-    public static final Color LIGHT_CAL_DAY_NAME_FG    = new Color(180, 180, 180);
-    public static final Color LIGHT_CAL_TODAY_BG       = new Color(255, 223, 100);
-    public static final Color LIGHT_CAL_THIS_MONTH_BG  = Color.WHITE;
-    public static final Color LIGHT_CAL_OTHER_MONTH_BG = new Color(245, 245, 245);
-    public static final Color LIGHT_CAL_OTHER_MONTH_FG = new Color(180, 180, 180);
-    public static final Color LIGHT_CAL_GRID_LINE      = new Color(220, 220, 220);
-    public static final Color LIGHT_CAL_HOVER_BORDER   = new Color(100, 150, 220);
-    public static final Color LIGHT_CAL_DATE_FG        = Color.DARK_GRAY;
-
-    public static final Color LIGHT_SIDEBAR_BG         = new Color(44, 44, 44);
-    public static final Color LIGHT_SIDEBAR_FG         = Color.WHITE;
-    public static final Color LIGHT_SIDEBAR_SEL_BG     = new Color(70, 70, 70);
-    public static final Color LIGHT_SIDEBAR_SEL_FG     = Color.WHITE;
-
-    public static final Color LIGHT_CONTENT_BG         = new Color(245, 245, 245);
-    public static final Color LIGHT_CONTENT_FG         = Color.BLACK;
-    public static final Color LIGHT_INPUT_BG           = Color.WHITE;
-    public static final Color LIGHT_INPUT_FG           = Color.BLACK;
-
-    // -----------------------------------------------------------------------
-    // Dark theme colors
-    // -----------------------------------------------------------------------
-    public static final Color DARK_CAL_HEADER_BG      = new Color(30, 30, 30);
-    public static final Color DARK_CAL_HEADER_FG      = new Color(220, 220, 220);
-    public static final Color DARK_CAL_DAY_NAME_BG    = new Color(40, 40, 40);
-    public static final Color DARK_CAL_DAY_NAME_FG    = new Color(150, 150, 150);
-    public static final Color DARK_CAL_TODAY_BG       = new Color(180, 140, 0);
-    public static final Color DARK_CAL_THIS_MONTH_BG  = new Color(50, 50, 55);
-    public static final Color DARK_CAL_OTHER_MONTH_BG = new Color(38, 38, 42);
-    public static final Color DARK_CAL_OTHER_MONTH_FG = new Color(100, 100, 100);
-    public static final Color DARK_CAL_GRID_LINE      = new Color(60, 60, 65);
-    public static final Color DARK_CAL_HOVER_BORDER   = new Color(80, 130, 200);
-    public static final Color DARK_CAL_DATE_FG        = new Color(200, 200, 200);
-
-    public static final Color DARK_SIDEBAR_BG         = new Color(28, 28, 28);
-    public static final Color DARK_SIDEBAR_FG         = new Color(220, 220, 220);
-    public static final Color DARK_SIDEBAR_SEL_BG     = new Color(60, 60, 60);
-    public static final Color DARK_SIDEBAR_SEL_FG     = Color.WHITE;
-
-    public static final Color DARK_CONTENT_BG         = new Color(45, 45, 48);
-    public static final Color DARK_CONTENT_FG         = new Color(220, 220, 220);
-    public static final Color DARK_INPUT_BG           = new Color(60, 60, 65);
-    public static final Color DARK_INPUT_FG           = new Color(220, 220, 220);
-
-    // -----------------------------------------------------------------------
-    // Singleton
-    // -----------------------------------------------------------------------
     private static final ThemeManager INSTANCE = new ThemeManager();
     private static final String PREF_KEY = "darkMode";
 
@@ -72,7 +19,8 @@ public class ThemeManager {
 
     private ThemeManager() {
         Preferences prefs = Preferences.userNodeForPackage(ThemeManager.class);
-        current = prefs.getBoolean(PREF_KEY, false) ? Theme.DARK : Theme.LIGHT;
+        // Dark-mode-first: default to dark when no saved preference exists.
+        current = prefs.getBoolean(PREF_KEY, true) ? Theme.DARK : Theme.LIGHT;
     }
 
     public static ThemeManager get() {
@@ -98,29 +46,4 @@ public class ThemeManager {
     public void addListener(Runnable r) {
         listeners.add(r);
     }
-
-    // -----------------------------------------------------------------------
-    // Convenience accessors — return the right color for the current theme
-    // -----------------------------------------------------------------------
-    public Color calHeaderBg()      { return isDark() ? DARK_CAL_HEADER_BG      : LIGHT_CAL_HEADER_BG; }
-    public Color calHeaderFg()      { return isDark() ? DARK_CAL_HEADER_FG      : LIGHT_CAL_HEADER_FG; }
-    public Color calDayNameBg()     { return isDark() ? DARK_CAL_DAY_NAME_BG    : LIGHT_CAL_DAY_NAME_BG; }
-    public Color calDayNameFg()     { return isDark() ? DARK_CAL_DAY_NAME_FG    : LIGHT_CAL_DAY_NAME_FG; }
-    public Color calTodayBg()       { return isDark() ? DARK_CAL_TODAY_BG       : LIGHT_CAL_TODAY_BG; }
-    public Color calThisMonthBg()   { return isDark() ? DARK_CAL_THIS_MONTH_BG  : LIGHT_CAL_THIS_MONTH_BG; }
-    public Color calOtherMonthBg()  { return isDark() ? DARK_CAL_OTHER_MONTH_BG : LIGHT_CAL_OTHER_MONTH_BG; }
-    public Color calOtherMonthFg()  { return isDark() ? DARK_CAL_OTHER_MONTH_FG : LIGHT_CAL_OTHER_MONTH_FG; }
-    public Color calGridLine()      { return isDark() ? DARK_CAL_GRID_LINE      : LIGHT_CAL_GRID_LINE; }
-    public Color calHoverBorder()   { return isDark() ? DARK_CAL_HOVER_BORDER   : LIGHT_CAL_HOVER_BORDER; }
-    public Color calDateFg()        { return isDark() ? DARK_CAL_DATE_FG        : LIGHT_CAL_DATE_FG; }
-
-    public Color sidebarBg()        { return isDark() ? DARK_SIDEBAR_BG         : LIGHT_SIDEBAR_BG; }
-    public Color sidebarFg()        { return isDark() ? DARK_SIDEBAR_FG         : LIGHT_SIDEBAR_FG; }
-    public Color sidebarSelBg()     { return isDark() ? DARK_SIDEBAR_SEL_BG     : LIGHT_SIDEBAR_SEL_BG; }
-    public Color sidebarSelFg()     { return isDark() ? DARK_SIDEBAR_SEL_FG     : LIGHT_SIDEBAR_SEL_FG; }
-
-    public Color contentBg()        { return isDark() ? DARK_CONTENT_BG         : LIGHT_CONTENT_BG; }
-    public Color contentFg()        { return isDark() ? DARK_CONTENT_FG         : LIGHT_CONTENT_FG; }
-    public Color inputBg()          { return isDark() ? DARK_INPUT_BG           : LIGHT_INPUT_BG; }
-    public Color inputFg()          { return isDark() ? DARK_INPUT_FG           : LIGHT_INPUT_FG; }
 }


### PR DESCRIPTION
The UI looks really bad on windows. Updated it using FlatLaf so that it's more consistent across devices. Also changed the 'New Class', 'Rename', and 'Delete' buttons to icons with tooltips that tell you what they do when you hover over them. Light and dark mode still work with the button @KennethPyron implemented.

## Old UI
<img width="1204" height="752" alt="AssignmentTracker_old_home" src="https://github.com/user-attachments/assets/d1ed1613-5d72-48b6-9247-b2eaeb67cf85" />
<img width="1204" height="752" alt="AssignmentTracker_old_dark_calendar" src="https://github.com/user-attachments/assets/a74ea7f6-9cfb-455f-9c63-b846963ec6da" />

## New UI
<img width="1100" height="650" alt="AssignmentTracker_new_calendar" src="https://github.com/user-attachments/assets/7524c093-c22d-425d-b765-93537b8b1a9d" />
<img width="1100" height="650" alt="AssignmentTracker_new_home" src="https://github.com/user-attachments/assets/b2388225-2166-48ad-b07d-1a020e9297be" />

