### PR TITLE
Add theme customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ replay_pid*
 CLAUDE.md
 
 # Superpowers brainstorming sessions
+docs/superpowers/
 .superpowers/
 
 # Git worktrees

--- a/build.xml
+++ b/build.xml
@@ -17,6 +17,8 @@
   <!-- FlatLaf: modern Look & Feel for Swing. Auto-downloaded like junit.jar. -->
   <property name="flatlaf.jar" value="lib/flatlaf-3.5.4.jar"/>
   <property name="flatlaf.url" value="https://repo1.maven.org/maven2/com/formdev/flatlaf/3.5.4/flatlaf-3.5.4.jar"/>
+  <property name="flatlaf-themes.jar" value="lib/flatlaf-intellij-themes-3.5.4.jar"/>
+  <property name="flatlaf-themes.url" value="https://repo1.maven.org/maven2/com/formdev/flatlaf-intellij-themes/3.5.4/flatlaf-intellij-themes-3.5.4.jar"/>
 
   <!-- Javadoc external API links. Uses the JDK running Ant; no hard-coded Java version. -->
   <condition property="javadoc.api.url" value="https://docs.oracle.com/javase/8/docs/api/">
@@ -95,9 +97,10 @@
     <delete dir="${dist.dir}"/>
   </target>
 
-  <target name="download-flatlaf" description="Download FlatLaf JAR if not present">
+  <target name="download-flatlaf" description="Download FlatLaf and FlatLaf IntelliJ Themes JARs if not present">
     <mkdir dir="lib"/>
     <get src="${flatlaf.url}" dest="${flatlaf.jar}" skipexisting="true"/>
+    <get src="${flatlaf-themes.url}" dest="${flatlaf-themes.jar}" skipexisting="true"/>
   </target>
 
   <target name="compile" depends="preflight, download-flatlaf" description="Compile Java source code">
@@ -108,6 +111,7 @@
            debug="true">
       <classpath>
         <pathelement path="${flatlaf.jar}"/>
+        <pathelement path="${flatlaf-themes.jar}"/>
       </classpath>
     </javac>
   </target>
@@ -122,6 +126,7 @@
         <attribute name="Implementation-Version" value="${app.version}"/>
       </manifest>
       <zipgroupfileset file="${flatlaf.jar}"/>
+      <zipgroupfileset file="${flatlaf-themes.jar}"/>
     </jar>
   </target>
 
@@ -237,6 +242,8 @@
       <classpath>
         <pathelement path="${build.dir}"/>
         <pathelement path="${junit.jar}"/>
+        <pathelement path="${flatlaf.jar}"/>
+        <pathelement path="${flatlaf-themes.jar}"/>
       </classpath>
     </javac>
   </target>

--- a/build.xml
+++ b/build.xml
@@ -2,7 +2,7 @@
 <project name="MyAntApp" default="package" basedir=".">
 
   <property name="app.name"    value="AssignmentTracker"/>
-  <property name="app.version" value="1.2.0"/>
+  <property name="app.version" value="1.2.1"/>
   <property name="main.class"  value="Main"/>
 
   <property name="src.dir"     value="src"/>

--- a/build.xml
+++ b/build.xml
@@ -251,7 +251,7 @@
   <target name="test" depends="test-compile" description="Run JUnit tests">
     <java jar="${junit.jar}" fork="true" failonerror="true">
       <arg value="execute"/>
-      <arg value="--class-path"/><arg value="${build.dir}:${test.build}"/>
+      <arg value="--class-path"/><arg value="${build.dir}${path.separator}${test.build}${path.separator}${flatlaf.jar}${path.separator}${flatlaf-themes.jar}"/>
       <arg value="--scan-class-path=${test.build}"/>
     </java>
   </target>

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,6 +1,4 @@
 import com.formdev.flatlaf.FlatDarkLaf;
-import com.formdev.flatlaf.FlatLaf;
-import com.formdev.flatlaf.FlatLightLaf;
 
 import javax.swing.*;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -27,11 +25,13 @@ public class Main {
      * @param args ignored
      */
     public static void main(String[] args) {
-        UIManager.put("@accentColor", new Color(99, 102, 241));
-        if (ThemeManager.get().isDark()) {
+        try {
+            ThemeManager.get().current().apply();
+        } catch (ThemeApplyException e) {
+            // Missing themes JAR or other classpath problem — fall back so
+            // the app still launches.
+            System.err.println("Could not apply saved theme: " + e.getMessage());
             FlatDarkLaf.setup();
-        } else {
-            FlatLightLaf.setup();
         }
         UIManager.put("Button.arc", 8);
         UIManager.put("TextComponent.arc", 6);
@@ -225,12 +225,6 @@ public class Main {
         addButton.setEnabled(false);
         removeButton.setEnabled(false);
 
-        JToggleButton darkModeToggle = new JToggleButton(theme.isDark() ? "☀" : "☽");
-        darkModeToggle.setSelected(theme.isDark());
-        darkModeToggle.setFocusPainted(false);
-        darkModeToggle.setToolTipText("Toggle dark/light mode");
-        darkModeToggle.putClientProperty("JButton.buttonType", "roundRect");
-
         JPanel inputLeft = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 8));
         inputLeft.add(new JLabel("Assignment:"));
         inputLeft.add(nameField);
@@ -248,9 +242,15 @@ public class Main {
         notifSettingsButton.putClientProperty("JButton.buttonType", "roundRect");
         notifSettingsButton.addActionListener(e -> notificationService.showSettingsDialog());
 
+        JButton prefsButton = new JButton("⚙"); // ⚙ gear
+        prefsButton.setToolTipText("Preferences");
+        prefsButton.setFocusPainted(false);
+        prefsButton.putClientProperty("JButton.buttonType", "roundRect");
+        prefsButton.addActionListener(e -> PreferencesDialog.show(frame));
+
         JPanel inputRight = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 8));
         inputRight.add(notifSettingsButton);
-        inputRight.add(darkModeToggle);
+        inputRight.add(prefsButton);
 
         JPanel inputPanel = new JPanel(new BorderLayout());
         inputPanel.setBorder(BorderFactory.createCompoundBorder(
@@ -306,22 +306,7 @@ public class Main {
         // Calendar panel
         CalendarPanel calendarPanel = new CalendarPanel(subjectListModel);
 
-        // Swap LAF on theme toggle.
         theme.addListener(() -> {
-            try {
-                UIManager.setLookAndFeel(theme.isDark()
-                        ? new FlatDarkLaf() : new FlatLightLaf());
-                FlatLaf.updateUI();
-            } catch (UnsupportedLookAndFeelException ex) {
-                System.err.println("Could not switch LAF: " + ex.getMessage());
-            }
-        });
-
-        //  Dark mode toggle action
-        darkModeToggle.addActionListener(e -> theme.toggle());
-
-        theme.addListener(() -> {
-            darkModeToggle.setText(theme.isDark() ? "☀" : "☽");
             // Rebuild input border so it picks up the new border color.
             inputPanel.setBorder(BorderFactory.createCompoundBorder(
                 BorderFactory.createMatteBorder(1, 0, 0, 0,

--- a/src/Main.java
+++ b/src/Main.java
@@ -25,6 +25,11 @@ public class Main {
      * @param args ignored
      */
     public static void main(String[] args) {
+        // Let FlatLaf draw the title bar and window border so they theme with
+        // the rest of the app. Must be set before any JFrame/JDialog is created.
+        JFrame.setDefaultLookAndFeelDecorated(true);
+        JDialog.setDefaultLookAndFeelDecorated(true);
+
         try {
             ThemeManager.get().current().apply();
         } catch (ThemeApplyException e) {

--- a/src/Main.java
+++ b/src/Main.java
@@ -360,6 +360,15 @@ public class Main {
             deleteButton.setEnabled(subjectSelected);
         });
 
+        // Combo auto-selects the first item when populated above, but the action
+        // listener wasn't attached yet — re-fire so the table picks up the saved
+        // assignments instead of staying on the empty placeholder model.
+        if (subjectList.getItemCount() > 0) {
+            int idx = Math.max(0, subjectList.getSelectedIndex());
+            subjectList.setSelectedIndex(-1);
+            subjectList.setSelectedIndex(idx);
+        }
+
         // Assignment actions
         addButton.addActionListener(e -> {
             Subject selected = (Subject) subjectList.getSelectedItem();

--- a/src/PreferencesDialog.java
+++ b/src/PreferencesDialog.java
@@ -1,0 +1,127 @@
+import javax.swing.*;
+import javax.swing.event.ListSelectionEvent;
+import java.awt.*;
+import java.lang.ref.WeakReference;
+
+/**
+ * Non-modal Preferences dialog containing a theme picker. Selection applies
+ * live via {@link ThemeManager#setCurrent(Theme)}; closing the dialog
+ * persists nothing extra.
+ */
+public final class PreferencesDialog extends JDialog {
+
+    private static WeakReference<PreferencesDialog> activeRef = new WeakReference<>(null);
+
+    /**
+     * Show the dialog, bringing the existing instance to front if it's
+     * already visible (preserves scroll / selection).
+     */
+    public static void show(Window owner) {
+        PreferencesDialog existing = activeRef.get();
+        if (existing != null && existing.isDisplayable() && existing.isVisible()) {
+            existing.toFront();
+            existing.requestFocus();
+            return;
+        }
+        PreferencesDialog dlg = new PreferencesDialog(owner);
+        activeRef = new WeakReference<>(dlg);
+        dlg.setVisible(true);
+    }
+
+    private PreferencesDialog(Window owner) {
+        super(owner, "Preferences", ModalityType.MODELESS);
+        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+        setSize(360, 420);
+        setLocationRelativeTo(owner);
+
+        JComponent themeSection = buildThemeSection();
+
+        JButton close = new JButton("Close");
+        close.putClientProperty("JButton.buttonType", "roundRect");
+        close.addActionListener(e -> dispose());
+
+        JPanel buttonBar = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 6));
+        buttonBar.add(close);
+
+        JPanel content = new JPanel(new BorderLayout());
+        content.setBorder(BorderFactory.createEmptyBorder(12, 12, 8, 12));
+        content.add(themeSection, BorderLayout.CENTER);
+        content.add(buttonBar, BorderLayout.SOUTH);
+
+        setContentPane(content);
+    }
+
+    /**
+     * Self-contained — when a future "Colors" or "Fonts" section lands,
+     * wrap this in a JTabbedPane.
+     */
+    private JComponent buildThemeSection() {
+        JLabel title = new JLabel("Theme");
+        title.setFont(title.getFont().deriveFont(Font.BOLD, 13f));
+        title.setBorder(BorderFactory.createEmptyBorder(0, 0, 8, 0));
+
+        DefaultListModel<Theme> model = new DefaultListModel<>();
+        for (Theme t : ThemeManager.get().presets()) model.addElement(t);
+
+        JList<Theme> list = new JList<>(model);
+        list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        list.setCellRenderer(new ThemeCellRenderer());
+        list.setSelectedValue(ThemeManager.get().current(), true);
+        list.addListSelectionListener((ListSelectionEvent e) -> {
+            if (e.getValueIsAdjusting()) return;
+            Theme selected = list.getSelectedValue();
+            if (selected != null && !selected.equals(ThemeManager.get().current())) {
+                ThemeManager.get().setCurrent(selected);
+            }
+        });
+
+        JScrollPane scroll = new JScrollPane(list);
+        scroll.setBorder(BorderFactory.createLineBorder(
+                UIManager.getColor("Component.borderColor")));
+
+        JPanel section = new JPanel(new BorderLayout());
+        section.add(title, BorderLayout.NORTH);
+        section.add(scroll, BorderLayout.CENTER);
+        return section;
+    }
+
+    /** Renders each row as [swatch] displayName. */
+    private static final class ThemeCellRenderer extends DefaultListCellRenderer {
+        @Override
+        public Component getListCellRendererComponent(JList<?> list, Object value,
+                                                      int index, boolean isSelected,
+                                                      boolean cellHasFocus) {
+            super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            if (value instanceof Theme) {
+                Theme t = (Theme) value;
+                setText("    " + t.displayName());
+                setIcon(new SwatchIcon(swatchColor(t)));
+                setBorder(BorderFactory.createEmptyBorder(4, 8, 4, 8));
+            }
+            return this;
+        }
+
+        private static Color swatchColor(Theme t) {
+            if (t.accent() != null) return t.accent();
+            // No accent override → use a neutral indicator based on light/dark.
+            return t.isDark() ? new Color(60, 60, 60) : new Color(220, 220, 220);
+        }
+    }
+
+    private static final class SwatchIcon implements Icon {
+        private final Color color;
+        SwatchIcon(Color color) { this.color = color; }
+        public int getIconWidth()  { return 12; }
+        public int getIconHeight() { return 12; }
+        public void paintIcon(Component c, Graphics g, int x, int y) {
+            Graphics2D g2 = (Graphics2D) g.create();
+            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                    RenderingHints.VALUE_ANTIALIAS_ON);
+            g2.setColor(color);
+            g2.fillRoundRect(x, y, getIconWidth(), getIconHeight(), 4, 4);
+            g2.setColor(new Color(0, 0, 0, 60));
+            g2.drawRoundRect(x, y, getIconWidth() - 1, getIconHeight() - 1, 4, 4);
+            g2.dispose();
+        }
+    }
+}

--- a/src/Theme.java
+++ b/src/Theme.java
@@ -1,0 +1,76 @@
+import com.formdev.flatlaf.FlatLaf;
+
+import javax.swing.LookAndFeel;
+import javax.swing.UIManager;
+import java.awt.Color;
+import java.util.Objects;
+
+/**
+ * Immutable description of a Look-and-Feel preset. Theme is identified by its
+ * {@code id} (used as the persistence key). {@link #apply()} installs the LAF
+ * by reflection on {@link #lafClassName()} and writes the optional accent
+ * override into {@code UIManager}.
+ */
+public final class Theme {
+    private final String id;
+    private final String displayName;
+    private final String lafClassName;
+    private final Color accent;
+    private final boolean dark;
+
+    public Theme(String id, String displayName, String lafClassName,
+                 Color accent, boolean dark) {
+        this.id = id;
+        this.displayName = displayName;
+        this.lafClassName = lafClassName;
+        this.accent = accent;
+        this.dark = dark;
+    }
+
+    public String id() { return id; }
+    public String displayName() { return displayName; }
+    public String lafClassName() { return lafClassName; }
+    public Color accent() { return accent; }
+    public boolean isDark() { return dark; }
+
+    /**
+     * Two Theme instances with the same {@code id} are considered equal even
+     * if their accent / displayName differ. {@code id} is the persistence key.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Theme)) return false;
+        return id.equals(((Theme) o).id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+
+    /**
+     * Install this theme's LAF, write its accent override (or clear it when
+     * {@code accent} is null), then refresh all open windows.
+     *
+     * @throws ThemeApplyException if the LAF class is missing or installation fails
+     */
+    public void apply() throws ThemeApplyException {
+        try {
+            LookAndFeel laf = (LookAndFeel) Class.forName(lafClassName)
+                    .getDeclaredConstructor().newInstance();
+            // Always set @accentColor — passing null removes the key, so the
+            // next FlatLaf refresh derives the accent from LAF defaults.
+            UIManager.put("@accentColor", accent);
+            UIManager.setLookAndFeel(laf);
+            FlatLaf.updateUI();
+        } catch (ReflectiveOperationException | javax.swing.UnsupportedLookAndFeelException e) {
+            throw new ThemeApplyException("Could not apply theme " + id + ": " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/Theme.java
+++ b/src/Theme.java
@@ -69,7 +69,8 @@ public final class Theme {
             UIManager.put("@accentColor", accent);
             UIManager.setLookAndFeel(laf);
             FlatLaf.updateUI();
-        } catch (ReflectiveOperationException | javax.swing.UnsupportedLookAndFeelException e) {
+        } catch (ReflectiveOperationException | ClassCastException
+               | javax.swing.UnsupportedLookAndFeelException e) {
             throw new ThemeApplyException("Could not apply theme " + id + ": " + e.getMessage(), e);
         }
     }

--- a/src/ThemeApplyException.java
+++ b/src/ThemeApplyException.java
@@ -1,0 +1,11 @@
+/**
+ * Thrown when a {@link Theme} cannot be applied — either because its LAF class
+ * is missing from the classpath, or because instantiating / installing the
+ * LAF fails. Callers should log and fall back; theming errors must never
+ * propagate to the event-dispatch thread.
+ */
+public class ThemeApplyException extends Exception {
+    public ThemeApplyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/ThemeManager.java
+++ b/src/ThemeManager.java
@@ -57,7 +57,18 @@ public final class ThemeManager {
     private final List<Runnable> listeners = new ArrayList<>();
 
     private ThemeManager() {
-        this.current = defaultTheme();
+        this.current = resolveStartupTheme();
+    }
+
+    private static Theme resolveStartupTheme() {
+        // 1. New key wins.
+        String savedId = prefsNode.get(KEY_THEME, null);
+        if (savedId != null) {
+            Theme found = findById(savedId);
+            if (found != null) return found;
+            // Unknown id → fall through to default WITHOUT overwriting the saved value.
+        }
+        return defaultTheme();
     }
 
     /** Test-only seam — redirects prefs reads/writes and forces the singleton to rebuild. */

--- a/src/ThemeManager.java
+++ b/src/ThemeManager.java
@@ -10,9 +10,8 @@ import java.util.prefs.Preferences;
  * a lazy lifecycle so {@link #setPreferencesNodeForTesting(Preferences)} can
  * redirect persistence before the instance is built.
  *
- * Public API matches the old class: {@link #get()}, {@link #addListener(Runnable)},
- * {@link #isDark()}. The old {@code toggle()} is replaced by
- * {@link #setCurrent(Theme)}; the old enum is replaced by {@link #presets()}.
+ * Public API: {@link #get()}, {@link #current()}, {@link #presets()},
+ * {@link #isDark()}, {@link #addListener(Runnable)}.
  */
 public final class ThemeManager {
 
@@ -86,12 +85,6 @@ public final class ThemeManager {
 
     public void addListener(Runnable r) {
         listeners.add(r);
-    }
-
-    public void setCurrent(Theme theme) {
-        current = theme;
-        prefsNode.put(KEY_THEME, theme.id());
-        for (Runnable r : listeners) r.run();
     }
 
     static Theme defaultTheme() {

--- a/src/ThemeManager.java
+++ b/src/ThemeManager.java
@@ -113,6 +113,20 @@ public final class ThemeManager {
         listeners.add(r);
     }
 
+    public void setCurrent(Theme t) {
+        this.current = t;
+        prefsNode.put(KEY_THEME, t.id());
+        try {
+            t.apply();
+        } catch (ThemeApplyException e) {
+            // Persist user intent even if applying fails this session — next
+            // launch will retry. Listeners still fire so border-rebuild etc.
+            // re-runs against whatever LAF is active.
+            System.err.println("Could not apply theme " + t.id() + ": " + e.getMessage());
+        }
+        for (Runnable r : listeners) r.run();
+    }
+
     static Theme defaultTheme() {
         return findById("default-dark");
     }

--- a/src/ThemeManager.java
+++ b/src/ThemeManager.java
@@ -67,7 +67,22 @@ public final class ThemeManager {
             Theme found = findById(savedId);
             if (found != null) return found;
             // Unknown id → fall through to default WITHOUT overwriting the saved value.
+            return defaultTheme();
         }
+
+        // 2. Migrate legacy boolean if present. Sentinel value distinguishes
+        //    "key absent" from "key present and false".
+        final boolean LEGACY_ABSENT_SENTINEL = true; // read with fake default = true
+        boolean legacyTrue  = prefsNode.getBoolean(KEY_DARKMODE, LEGACY_ABSENT_SENTINEL);
+        boolean legacyFalse = prefsNode.getBoolean(KEY_DARKMODE, false);
+        boolean legacyKeyExists = legacyTrue == legacyFalse; // both reads return same value
+        if (legacyKeyExists) {
+            String migratedId = legacyTrue ? "default-dark" : "default-light";
+            prefsNode.put(KEY_THEME, migratedId);
+            return findById(migratedId);
+        }
+
+        // 3. No prefs → default-dark.
         return defaultTheme();
     }
 

--- a/src/ThemeManager.java
+++ b/src/ThemeManager.java
@@ -50,8 +50,8 @@ public final class ThemeManager {
                     null, true)
     ));
 
-    private static Preferences prefsNode = Preferences.userNodeForPackage(ThemeManager.class);
-    private static ThemeManager instance;
+    private static volatile Preferences prefsNode = Preferences.userNodeForPackage(ThemeManager.class);
+    private static volatile ThemeManager instance;
 
     private Theme current;
     private final List<Runnable> listeners = new ArrayList<>();

--- a/src/ThemeManager.java
+++ b/src/ThemeManager.java
@@ -1,30 +1,79 @@
+import java.awt.Color;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.prefs.Preferences;
 
 /**
- * Tracks the current light/dark theme preference and notifies listeners when
- * it changes. Actual component colors come from FlatLaf via UIManager — this
- * class only owns the on/off switch and the persistence of that choice.
+ * Owns the active {@link Theme} and the curated preset list. Singleton with
+ * a lazy lifecycle so {@link #setPreferencesNodeForTesting(Preferences)} can
+ * redirect persistence before the instance is built.
+ *
+ * Public API matches the old class: {@link #get()}, {@link #addListener(Runnable)},
+ * {@link #isDark()}. The old {@code toggle()} is replaced by
+ * {@link #setCurrent(Theme)}; the old enum is replaced by {@link #presets()}.
  */
-public class ThemeManager {
+public final class ThemeManager {
 
-    public enum Theme { LIGHT, DARK }
+    private static final String KEY_THEME    = "themeId";
+    private static final String KEY_DARKMODE = "darkMode"; // legacy, read-only
 
-    private static final ThemeManager INSTANCE = new ThemeManager();
-    private static final String PREF_KEY = "darkMode";
+    private static final List<Theme> PRESETS = Collections.unmodifiableList(Arrays.asList(
+            new Theme("default-dark",    "Default Dark",
+                    "com.formdev.flatlaf.FlatDarkLaf",
+                    new Color(99, 102, 241), true),
+            new Theme("default-light",   "Default Light",
+                    "com.formdev.flatlaf.FlatLightLaf",
+                    new Color(99, 102, 241), false),
+            new Theme("github-light",    "GitHub Light",
+                    "com.formdev.flatlaf.intellijthemes.FlatGitHubIJTheme",
+                    null, false),
+            new Theme("solarized-dark",  "Solarized Dark",
+                    "com.formdev.flatlaf.intellijthemes.FlatSolarizedDarkIJTheme",
+                    null, true),
+            new Theme("solarized-light", "Solarized Light",
+                    "com.formdev.flatlaf.intellijthemes.FlatSolarizedLightIJTheme",
+                    null, false),
+            new Theme("dracula",         "Dracula",
+                    "com.formdev.flatlaf.intellijthemes.FlatDraculaIJTheme",
+                    null, true),
+            new Theme("nord",            "Nord",
+                    "com.formdev.flatlaf.intellijthemes.FlatNordIJTheme",
+                    null, true),
+            new Theme("one-dark",        "One Dark",
+                    "com.formdev.flatlaf.intellijthemes.FlatOneDarkIJTheme",
+                    null, true),
+            // FlatLaf class name has a typo ("Monocai" instead of "Monokai") —
+            // do not "fix" or the theme will fail to load.
+            new Theme("monokai-pro",     "Monokai Pro",
+                    "com.formdev.flatlaf.intellijthemes.FlatMonocaiProIJTheme",
+                    null, true)
+    ));
+
+    private static Preferences prefsNode = Preferences.userNodeForPackage(ThemeManager.class);
+    private static ThemeManager instance;
 
     private Theme current;
     private final List<Runnable> listeners = new ArrayList<>();
 
     private ThemeManager() {
-        Preferences prefs = Preferences.userNodeForPackage(ThemeManager.class);
-        // Dark-mode-first: default to dark when no saved preference exists.
-        current = prefs.getBoolean(PREF_KEY, true) ? Theme.DARK : Theme.LIGHT;
+        this.current = defaultTheme();
     }
 
-    public static ThemeManager get() {
-        return INSTANCE;
+    /** Test-only seam — redirects prefs reads/writes and forces the singleton to rebuild. */
+    static void setPreferencesNodeForTesting(Preferences node) {
+        prefsNode = node;
+        instance = null;
+    }
+
+    public static synchronized ThemeManager get() {
+        if (instance == null) instance = new ThemeManager();
+        return instance;
+    }
+
+    public List<Theme> presets() {
+        return PRESETS;
     }
 
     public Theme current() {
@@ -32,18 +81,25 @@ public class ThemeManager {
     }
 
     public boolean isDark() {
-        return current == Theme.DARK;
-    }
-
-    /** Toggles between light and dark, persists preference, notifies listeners. */
-    public void toggle() {
-        current = isDark() ? Theme.LIGHT : Theme.DARK;
-        Preferences prefs = Preferences.userNodeForPackage(ThemeManager.class);
-        prefs.putBoolean(PREF_KEY, isDark());
-        for (Runnable r : listeners) r.run();
+        return current.isDark();
     }
 
     public void addListener(Runnable r) {
         listeners.add(r);
+    }
+
+    public void setCurrent(Theme theme) {
+        current = theme;
+        prefsNode.put(KEY_THEME, theme.id());
+        for (Runnable r : listeners) r.run();
+    }
+
+    static Theme defaultTheme() {
+        return findById("default-dark");
+    }
+
+    static Theme findById(String id) {
+        for (Theme t : PRESETS) if (t.id().equals(id)) return t;
+        return null;
     }
 }

--- a/src/ThemeManager.java
+++ b/src/ThemeManager.java
@@ -26,7 +26,7 @@ public final class ThemeManager {
                     "com.formdev.flatlaf.FlatLightLaf",
                     new Color(99, 102, 241), false),
             new Theme("github-light",    "GitHub Light",
-                    "com.formdev.flatlaf.intellijthemes.FlatGitHubIJTheme",
+                    "com.formdev.flatlaf.intellijthemes.materialthemeuilite.FlatGitHubIJTheme",
                     null, false),
             new Theme("solarized-dark",  "Solarized Dark",
                     "com.formdev.flatlaf.intellijthemes.FlatSolarizedDarkIJTheme",
@@ -43,10 +43,8 @@ public final class ThemeManager {
             new Theme("one-dark",        "One Dark",
                     "com.formdev.flatlaf.intellijthemes.FlatOneDarkIJTheme",
                     null, true),
-            // FlatLaf class name has a typo ("Monocai" instead of "Monokai") —
-            // do not "fix" or the theme will fail to load.
             new Theme("monokai-pro",     "Monokai Pro",
-                    "com.formdev.flatlaf.intellijthemes.FlatMonocaiProIJTheme",
+                    "com.formdev.flatlaf.intellijthemes.FlatMonokaiProIJTheme",
                     null, true)
     ));
 

--- a/test/SubjectTest.java
+++ b/test/SubjectTest.java
@@ -28,7 +28,7 @@ public class SubjectTest {
         DefaultTableModel model = subject.getTableModel();
         assertNotNull(model);
         assertEquals(0, model.getRowCount());
-        assertEquals(3, model.getColumnCount());
+        assertEquals(4, model.getColumnCount());
     }
 
     @Test
@@ -37,6 +37,7 @@ public class SubjectTest {
         assertEquals("Assignment", model.getColumnName(0));
         assertEquals("Due Date", model.getColumnName(1));
         assertEquals("Done", model.getColumnName(2));
+        assertEquals("Notes", model.getColumnName(3));
     }
 
     @Test
@@ -45,6 +46,7 @@ public class SubjectTest {
         assertEquals(String.class, model.getColumnClass(0));
         assertEquals(String.class, model.getColumnClass(1));
         assertEquals(Boolean.class, model.getColumnClass(2));
+        assertEquals(String.class, model.getColumnClass(3));
     }
 
     // --- setName ---

--- a/test/ThemeManagerTest.java
+++ b/test/ThemeManagerTest.java
@@ -49,4 +49,17 @@ public class ThemeManagerTest {
                 "solarized-dark", "solarized-light", "dracula",
                 "nord", "one-dark", "monokai-pro"), ids);
     }
+
+    @Test
+    void startup_savedThemeId_isLoaded() {
+        testNode.put("themeId", "dracula");
+        ThemeManager.setPreferencesNodeForTesting(testNode); // forces rebuild
+        assertEquals("dracula", ThemeManager.get().current().id());
+    }
+
+    @Test
+    void startup_noPrefs_defaultsToDefaultDark() {
+        // testNode is fresh and empty; rebuilt in @BeforeEach
+        assertEquals("default-dark", ThemeManager.get().current().id());
+    }
 }

--- a/test/ThemeManagerTest.java
+++ b/test/ThemeManagerTest.java
@@ -102,4 +102,28 @@ public class ThemeManagerTest {
         assertEquals("no-such-theme", testNode.get("themeId", null),
                 "saved themeId must not be overwritten on fallback");
     }
+
+    @Test
+    void setCurrent_persistsThemeId() {
+        Theme dracula = ThemeManager.findById("dracula");
+        ThemeManager.get().setCurrent(dracula);
+        assertEquals("dracula", testNode.get("themeId", null));
+        assertEquals("dracula", ThemeManager.get().current().id());
+    }
+
+    @Test
+    void setCurrent_firesListeners() {
+        int[] callCount = {0};
+        ThemeManager.get().addListener(() -> callCount[0]++);
+        ThemeManager.get().setCurrent(ThemeManager.findById("nord"));
+        assertEquals(1, callCount[0]);
+    }
+
+    @Test
+    void setCurrent_isDarkReflectsCurrent() {
+        ThemeManager.get().setCurrent(ThemeManager.findById("default-light"));
+        assertFalse(ThemeManager.get().isDark());
+        ThemeManager.get().setCurrent(ThemeManager.findById("default-dark"));
+        assertTrue(ThemeManager.get().isDark());
+    }
 }

--- a/test/ThemeManagerTest.java
+++ b/test/ThemeManagerTest.java
@@ -62,4 +62,35 @@ public class ThemeManagerTest {
         // testNode is fresh and empty; rebuilt in @BeforeEach
         assertEquals("default-dark", ThemeManager.get().current().id());
     }
+
+    @Test
+    void migration_legacyDarkModeTrue_mapsToDefaultDark() {
+        testNode.putBoolean("darkMode", true);
+        ThemeManager.setPreferencesNodeForTesting(testNode);
+        assertEquals("default-dark", ThemeManager.get().current().id());
+        assertEquals("default-dark", testNode.get("themeId", null),
+                "themeId should be persisted after migration");
+    }
+
+    @Test
+    void migration_legacyDarkModeFalse_mapsToDefaultLight() {
+        testNode.putBoolean("darkMode", false);
+        ThemeManager.setPreferencesNodeForTesting(testNode);
+        assertEquals("default-light", ThemeManager.get().current().id());
+        assertEquals("default-light", testNode.get("themeId", null));
+    }
+
+    @Test
+    void migration_runsOnlyOnce_subsequentLoadsUseThemeId() {
+        // First load migrates.
+        testNode.putBoolean("darkMode", true);
+        ThemeManager.setPreferencesNodeForTesting(testNode);
+        assertEquals("default-dark", ThemeManager.get().current().id());
+
+        // Now manually flip darkMode to false; themeId should still win.
+        testNode.putBoolean("darkMode", false);
+        ThemeManager.setPreferencesNodeForTesting(testNode);
+        assertEquals("default-dark", ThemeManager.get().current().id(),
+                "themeId should override the legacy darkMode key");
+    }
 }

--- a/test/ThemeManagerTest.java
+++ b/test/ThemeManagerTest.java
@@ -93,4 +93,13 @@ public class ThemeManagerTest {
         assertEquals("default-dark", ThemeManager.get().current().id(),
                 "themeId should override the legacy darkMode key");
     }
+
+    @Test
+    void bogusThemeId_fallsBackToDefault_doesNotOverwriteSavedValue() {
+        testNode.put("themeId", "no-such-theme");
+        ThemeManager.setPreferencesNodeForTesting(testNode);
+        assertEquals("default-dark", ThemeManager.get().current().id());
+        assertEquals("no-such-theme", testNode.get("themeId", null),
+                "saved themeId must not be overwritten on fallback");
+    }
 }

--- a/test/ThemeManagerTest.java
+++ b/test/ThemeManagerTest.java
@@ -1,0 +1,52 @@
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.prefs.Preferences;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link ThemeManager}. Each test gets a fresh transient
+ * Preferences sub-node so the developer's real prefs are never touched.
+ */
+public class ThemeManagerTest {
+
+    private Preferences testNode;
+
+    @BeforeEach
+    void setUpPrefs() {
+        testNode = Preferences.userRoot().node("at-test-" + UUID.randomUUID());
+        ThemeManager.setPreferencesNodeForTesting(testNode);
+    }
+
+    @AfterEach
+    void tearDownPrefs() throws Exception {
+        testNode.removeNode();
+        ThemeManager.setPreferencesNodeForTesting(
+                Preferences.userNodeForPackage(ThemeManager.class));
+    }
+
+    @Test
+    void presets_isNonEmpty() {
+        List<Theme> ps = ThemeManager.get().presets();
+        assertFalse(ps.isEmpty());
+    }
+
+    @Test
+    void presets_containsBothDefaults() {
+        List<Theme> ps = ThemeManager.get().presets();
+        assertTrue(ps.contains(new Theme("default-dark", "", "", null, true)));
+        assertTrue(ps.contains(new Theme("default-light", "", "", null, false)));
+    }
+
+    @Test
+    void presets_containsAllNineExpectedIds() {
+        List<String> ids = new java.util.ArrayList<>();
+        for (Theme t : ThemeManager.get().presets()) ids.add(t.id());
+        assertEquals(java.util.Arrays.asList(
+                "default-dark", "default-light", "github-light",
+                "solarized-dark", "solarized-light", "dracula",
+                "nord", "one-dark", "monokai-pro"), ids);
+    }
+}

--- a/test/ThemeTest.java
+++ b/test/ThemeTest.java
@@ -1,0 +1,84 @@
+import com.formdev.flatlaf.FlatDarkLaf;
+import com.formdev.flatlaf.FlatLightLaf;
+import org.junit.jupiter.api.*;
+
+import javax.swing.UIManager;
+import java.awt.Color;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link Theme} — equality semantics and the apply() side effects
+ * we can observe headlessly (UIManager state).
+ */
+public class ThemeTest {
+
+    @AfterEach
+    void resetLaf() throws Exception {
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        UIManager.put("@accentColor", null);
+    }
+
+    @Test
+    void equals_keyedOnId_sameId_areEqual() {
+        Theme a = new Theme("x", "X", "com.formdev.flatlaf.FlatLightLaf", null, false);
+        Theme b = new Theme("x", "Different Display", "com.formdev.flatlaf.FlatDarkLaf",
+                new Color(1, 2, 3), true);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    void equals_differentId_notEqual() {
+        Theme a = new Theme("x", "X", "com.formdev.flatlaf.FlatLightLaf", null, false);
+        Theme b = new Theme("y", "X", "com.formdev.flatlaf.FlatLightLaf", null, false);
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    void getters_returnConstructorValues() {
+        Color accent = new Color(99, 102, 241);
+        Theme t = new Theme("default-dark", "Default Dark",
+                "com.formdev.flatlaf.FlatDarkLaf", accent, true);
+        assertEquals("default-dark", t.id());
+        assertEquals("Default Dark", t.displayName());
+        assertEquals("com.formdev.flatlaf.FlatDarkLaf", t.lafClassName());
+        assertEquals(accent, t.accent());
+        assertTrue(t.isDark());
+    }
+
+    @Test
+    void apply_validClass_setsLookAndFeel() throws Exception {
+        Theme t = new Theme("default-light", "Default Light",
+                "com.formdev.flatlaf.FlatLightLaf", null, false);
+        t.apply();
+        assertTrue(UIManager.getLookAndFeel() instanceof FlatLightLaf,
+                "expected FlatLightLaf, got " + UIManager.getLookAndFeel().getClass());
+    }
+
+    @Test
+    void apply_withAccent_putsAccentColorInUIManager() throws Exception {
+        Color accent = new Color(99, 102, 241);
+        Theme t = new Theme("default-dark", "Default Dark",
+                "com.formdev.flatlaf.FlatDarkLaf", accent, true);
+        t.apply();
+        assertEquals(accent, UIManager.get("@accentColor"));
+    }
+
+    @Test
+    void apply_withNullAccent_clearsAccentColor() throws Exception {
+        UIManager.put("@accentColor", new Color(255, 0, 0));
+        Theme t = new Theme("nord", "Nord",
+                "com.formdev.flatlaf.FlatDarkLaf", null, true);
+        t.apply();
+        assertNull(UIManager.get("@accentColor"));
+    }
+
+    @Test
+    void apply_bogusClass_throwsThemeApplyException() {
+        Theme t = new Theme("bogus", "Bogus",
+                "com.formdev.flatlaf.DoesNotExistLaf", null, true);
+        ThemeApplyException ex = assertThrows(ThemeApplyException.class, t::apply);
+        assertNotNull(ex.getCause());
+    }
+}

--- a/test/ThemeTest.java
+++ b/test/ThemeTest.java
@@ -81,4 +81,14 @@ public class ThemeTest {
         ThemeApplyException ex = assertThrows(ThemeApplyException.class, t::apply);
         assertNotNull(ex.getCause());
     }
+
+    @Test
+    void apply_classExistsButIsNotLookAndFeel_throwsThemeApplyException() {
+        // java.lang.String exists but is not a LookAndFeel — the cast fails.
+        Theme t = new Theme("not-a-laf", "Not LAF", "java.lang.String", null, true);
+        ThemeApplyException ex = assertThrows(ThemeApplyException.class, t::apply);
+        assertNotNull(ex.getCause());
+        assertTrue(ex.getCause() instanceof ClassCastException,
+                "expected ClassCastException cause, got " + ex.getCause().getClass());
+    }
 }


### PR DESCRIPTION
## Summary
Closes #24 
- Replaces the binary light/dark toggle with a 9-preset theme picker behind a new Preferences dialog (gear button in the header).
- Curated presets bundle FlatLaf core (Default Dark/Light) with seven IntelliJ Themes (GitHub Light, Solarized Dark/Light, Dracula, Nord, One Dark, Monokai Pro). Each preset is a full LAF — light/dark mood is baked in, so the standalone toggle goes away.
- FlatLaf-drawn title bar and window border, so the OS chrome themes with the rest of the app.
- Persistence migrates one-shot from the legacy `darkMode` boolean to a new `themeId` string. Unknown saved IDs fall back to Default Dark without overwriting the saved value (downgrade-safe).
- 17 new unit tests (Theme + ThemeManager) covering equality, apply paths, prefs round-trip, legacy migration both directions, and unknown-ID fallback. 48 tests total, all green.
- Includes one drive-by fix on \`main\` already merged in: stale \`SubjectTest\` was asserting 3 columns when the table model has 4 (Notes column added previously).
<img width="1204" height="744" alt="image" src="https://github.com/user-attachments/assets/ad8bfe5c-92b7-4fc3-8261-3681ae70575e" />
<img width="1204" height="744" alt="image" src="https://github.com/user-attachments/assets/bf7ff451-a7dc-40ce-813d-5263d186557e" />
<img width="1204" height="744" alt="image" src="https://github.com/user-attachments/assets/3cf2b496-7bd9-4b70-9403-2ba2391cddcd" />